### PR TITLE
Issue #8 - Fixed gap between content and footer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,7 +152,7 @@
 
 /*--------------------------------------------------------------------- About Page ----------------------------------------------*/
 .content {
-  margin-bottom: 25px;
+  margin-bottom: 0;
 }
 
 .info {
@@ -160,6 +160,7 @@
 }
 
 #map {
+  margin-bottom: 25px !important;
   height: 600px;
   width: 80%;
 }


### PR DESCRIPTION
Found that the gap was for the map on the 'About Us' page. Removed the margin-bottom on the content class and applied it to the map id.